### PR TITLE
Ignore links starting with '/' or './' for lint

### DIFF
--- a/scripts/markdown-link-check-config.json
+++ b/scripts/markdown-link-check-config.json
@@ -2,6 +2,9 @@
     "ignorePatterns": [
         {
             "pattern": "^https?://localhost($|[:/].*)"
+        },
+        {
+            "pattern": "^.?[/][\\w].*"
         }
     ]
 }


### PR DESCRIPTION
Links containing a file path relative to a Github repo were failing lint checks. Let's exclude those links so that lint doesn't give false errors. 

The regex matches for any text starting with 0 or 1 dots, followed by a slash, followed by at least one character. 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #445
